### PR TITLE
Add Google Analytics tracking to site

### DIFF
--- a/404.html
+++ b/404.html
@@ -16,6 +16,16 @@ permalink: /404.html
       height: auto;
     }
   </style>
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SX2JP3SZ98"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-SX2JP3SZ98');
+  </script>
 </head>
 <body>
   <h1>404 - Lost in Space</h1>

--- a/_config.yml
+++ b/_config.yml
@@ -13,3 +13,5 @@ readme_index:
 
 title: Engineering 100-980
 description: "Homepage of UMich ENGR 100-980: Rocket Science"
+
+google_analytics: G-SX2JP3SZ98

--- a/facilities.html
+++ b/facilities.html
@@ -142,6 +142,16 @@ toc: false
       }
     }
   </style>
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SX2JP3SZ98"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-SX2JP3SZ98');
+  </script>
 </head>
 <body>
   <nav class="navbar">

--- a/googlec5646e24ea3a977c.html
+++ b/googlec5646e24ea3a977c.html
@@ -1,1 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SX2JP3SZ98"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-SX2JP3SZ98');
+  </script>
+</head>
+<body>
 google-site-verification: googlec5646e24ea3a977c.html
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -181,6 +181,16 @@ toc: false
       }
     }
   </style>
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SX2JP3SZ98"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-SX2JP3SZ98');
+  </script>
 </head>
 <body>
   <nav class="navbar">

--- a/staff.html
+++ b/staff.html
@@ -143,6 +143,16 @@ toc: false
       }
     }
   </style>
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SX2JP3SZ98"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-SX2JP3SZ98');
+  </script>
 </head>
 <body>
   <nav class="navbar">


### PR DESCRIPTION
## Summary
- enable Google Analytics tracking via `_config.yml`
- embed Google Analytics script tag into each standalone HTML page

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2381c17c0832cbbca7886f8c1810e